### PR TITLE
chatops fixed

### DIFF
--- a/config/grue-support.config
+++ b/config/grue-support.config
@@ -1,10 +1,14 @@
  {
+
+
     "infillDensity" : 0.05,  // unit: ratio to solid
     "numberOfShells" : 2, //Number of shells to print
     "insetDistanceMultiplier" : 1.05,  // unit: layerW // how far apart are insets from each other
     "roofLayerCount" : 5,  // nb of extra solid layers for roofs
     "floorLayerCount" : 5, // nb of extra solid layers for floor
     "layerWidthRatio" : 1.67,  //Width over height ratio
+    "layerWidthMinimum"            : 0.4,   // layers cannot be narrower than this
+    "layerWidthMaximum"            : 0.85,  //layers cannot be wider than this
     "preCoarseness" : 0.1, //coarseness before all processing
     "coarseness" : 0.05, // moves shorter than this are combined
     "directionWeight" : 0.5,
@@ -13,6 +17,15 @@
     "doOutlines" : false,
     "doInfills" : true,
     "doInsets" : true,
+
+    "doExternalSpurs" : true,
+    "doInternalSpurs" : false,
+    "minSpurWidth" : 0.12, // 0.3 * default layer width
+    "maxSpurWidth" : 0.4, // default layer width plus 0.2
+    "minSpurLength": 0.4,
+    "spurOverlap" : 0.001, // how far to extend spur segments to make them intersect
+
+
 
     "doGraphOptimization" : true,  // do we want to apply our graph optimization?
     "iterativeEffort" : 999, // max number of iterations to run after graph, sanity check only

--- a/server/app.rb
+++ b/server/app.rb
@@ -120,10 +120,10 @@ module MakeMe
         :floorLayerCount => floors,
         :numberOfShells => shells,
         :extrusionProfiles => {
-          :insets => temp,
-          :infill => temp,
-          :firstlayer => temp,
-          :outlines => temp,
+          :insets => { :temperature => temp, :feedrate => 80 },
+          :infill => { :temperature => temp, :feedrate => 80 },
+          :firstlayer => { :temperature => temp, :feedrate => 50 },
+          :outlines => { :temperature => temp, :feedrate => 50 },
         }
       }.merge(slicer_args)
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -16,7 +16,7 @@ s3g/virtualenv/bin/activate:
 
 ## System
 brews:
-	@brew install avrdude || echo "AVRDude already brew installed [or failed]"
-	@brew install scons || echo "scons already brew installed [or failed]"
+	apt-get install -y avrdude || echo "AVRDude already brew installed [or failed]"
+	apt-get install -y scons || echo "scons already brew installed [or failed]"
 
 .PHONY: all brews grue s3g


### PR DESCRIPTION
chatops kept getting the error 

```
miracle_grue: submodule/json-cpp/src/lib_json/json_value.cpp:1189: const Json::Value& Json::Value::operator[](const char*) const: Assertion `type_ == nullValue || type_ == objectValue' failed.
make: *** [/opt/make-me/data/print.gcode] Error 134
```

so we added an `strace -fo /tmp/wtf` to https://github.com/jfryman/make-me/blob/master/Makefile#L42 and a `std::cout << key << std::endl;` before https://github.com/makerbot/json-cpp/blob/6ffeba338646ab2fc632b8964699eff1a4152e46/src/lib_json/json_value.cpp#L1187 which showed us that the submodule was erroring out right as it tried to get the value for `feedrate` which was not in the grue-make-me.config referenced in the makefile https://github.com/jfryman/make-me/blob/master/Makefile#L42 by replacing `grue-$(GRUE_CONFIG).config` with `grue-default.config` it allowed us to print with chatops, but the raft and supports features will not work as those are evidently features of the grue-make-me-config generated by MakeMe::MiracleGrueConfigurator.new here https://github.com/jfryman/make-me/blob/master/server/app.rb#L130

This PR adds the feedrate attr to the slicer args passed to the config generator that was causing the issue.
